### PR TITLE
Remove dead links to the code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,3 @@ Contributing
 ----------
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/crdschurch/jekyll-asset-pipeline. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
-
-Code of Conduct
-----------
-
-Everyone interacting in the Jekyll::Asset::Pipeline project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/crdschurch/jekyll-asset-pipeline/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
The code of conduct has been removed some time ago apparently.